### PR TITLE
Set reservation on JobConfiguration

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -92,6 +92,9 @@ func (c *connection) jobConfiguration(query string) (*bigquery.Job, error) {
 		}
 	}
 	job.Configuration.Query = configQuery
+	if c.cfg.Reservation != "" {
+		job.Configuration.Reservation = c.cfg.Reservation
+	}
 	return job, nil
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,77 @@
+package bigquery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobConfiguration_Reservation(t *testing.T) {
+	var testCases = []struct {
+		description         string
+		cfg                 *Config
+		query               string
+		expectedReservation string
+		expectedPriority    string
+	}{
+		{
+			description: "reservation set from config",
+			cfg: &Config{
+				ProjectID:   "myproject",
+				DatasetID:   "mydataset",
+				Priority:    PriorityInteractive,
+				Reservation: "projects/myproject/locations/us/reservations/myreservation",
+			},
+			query:               "SELECT 1",
+			expectedReservation: "projects/myproject/locations/us/reservations/myreservation",
+			expectedPriority:    PriorityInteractive,
+		},
+		{
+			description: "no reservation when not configured",
+			cfg: &Config{
+				ProjectID: "myproject",
+				DatasetID: "mydataset",
+				Priority:  PriorityInteractive,
+			},
+			query:               "SELECT 1",
+			expectedReservation: "",
+			expectedPriority:    PriorityInteractive,
+		},
+		{
+			description: "reservation with batch priority",
+			cfg: &Config{
+				ProjectID:   "myproject",
+				DatasetID:   "mydataset",
+				Priority:    PriorityBatch,
+				Reservation: "projects/myproject/locations/us/reservations/prod",
+			},
+			query:               "SELECT 1",
+			expectedReservation: "projects/myproject/locations/us/reservations/prod",
+			expectedPriority:    PriorityBatch,
+		},
+		{
+			description: "priority from hint overrides config priority but reservation still set",
+			cfg: &Config{
+				ProjectID:   "myproject",
+				DatasetID:   "mydataset",
+				Priority:    PriorityInteractive,
+				Reservation: "projects/myproject/locations/us/reservations/myreservation",
+			},
+			query:               `SELECT /*+ {"Priority": "BATCH"} +*/ 1`,
+			expectedReservation: "projects/myproject/locations/us/reservations/myreservation",
+			expectedPriority:    PriorityBatch,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			conn := &connection{cfg: tc.cfg, projectID: tc.cfg.ProjectID}
+			job, err := conn.jobConfiguration(tc.query)
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, tc.expectedReservation, job.Configuration.Reservation)
+			assert.Equal(t, tc.expectedPriority, job.Configuration.Query.Priority)
+		})
+	}
+}

--- a/dsn.go
+++ b/dsn.go
@@ -27,6 +27,7 @@ const (
 	app                = "app"
 	defaultApp         = "go-sql-bq"
 	priority           = "priority"
+	reservation        = "reservation"
 
 	// Priority values
 	PriorityInteractive = "INTERACTIVE"
@@ -53,7 +54,8 @@ type Config struct {
 	App             string
 	OAuth2ConfigURL string
 	OAuth2TokenURL  string
-	Priority        string // Job priority: "INTERACTIVE" (default) or "BATCH"
+	Priority    string // Job priority: "INTERACTIVE" (default) or "BATCH"
+	Reservation string // Reservation for query jobs: "projects/{project}/locations/{location}/reservations/{reservation}"
 	url.Values
 }
 
@@ -155,6 +157,9 @@ func ParseDSN(dsn string) (*Config, error) {
 		}
 		if _, ok := cfg.Values[priority]; ok {
 			cfg.Priority = strings.ToUpper(cfg.Values.Get(priority))
+		}
+		if _, ok := cfg.Values[reservation]; ok {
+			cfg.Reservation = cfg.Values.Get(reservation)
 		}
 	}
 

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1,0 +1,98 @@
+package bigquery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDSN(t *testing.T) {
+	var testCases = []struct {
+		description string
+		dsn         string
+		expect      Config
+		expectError bool
+	}{
+		{
+			description: "basic DSN with project and dataset",
+			dsn:         "bigquery://myproject/us/mydataset",
+			expect: Config{
+				ProjectID: "myproject",
+				DatasetID: "mydataset",
+				Location:  "us",
+				App:       defaultApp,
+				Priority:  PriorityInteractive,
+			},
+		},
+		{
+			description: "DSN with batch priority",
+			dsn:         "bigquery://myproject/us/mydataset?priority=batch",
+			expect: Config{
+				ProjectID: "myproject",
+				DatasetID: "mydataset",
+				Location:  "us",
+				App:       defaultApp,
+				Priority:  PriorityBatch,
+			},
+		},
+		{
+			description: "DSN with reservation",
+			dsn:         "bigquery://myproject/us/mydataset?reservation=projects/myproject/locations/us/reservations/myreservation",
+			expect: Config{
+				ProjectID:   "myproject",
+				DatasetID:   "mydataset",
+				Location:    "us",
+				App:         defaultApp,
+				Priority:    PriorityInteractive,
+				Reservation: "projects/myproject/locations/us/reservations/myreservation",
+			},
+		},
+		{
+			description: "DSN with reservation and priority",
+			dsn:         "bigquery://myproject/us/mydataset?reservation=projects/myproject/locations/us/reservations/myreservation&priority=batch",
+			expect: Config{
+				ProjectID:   "myproject",
+				DatasetID:   "mydataset",
+				Location:    "us",
+				App:         defaultApp,
+				Priority:    PriorityBatch,
+				Reservation: "projects/myproject/locations/us/reservations/myreservation",
+			},
+		},
+		{
+			description: "DSN without location defaults to us",
+			dsn:         "bigquery://myproject/mydataset",
+			expect: Config{
+				ProjectID: "myproject",
+				DatasetID: "mydataset",
+				Location:  "us",
+				App:       defaultApp,
+				Priority:  PriorityInteractive,
+			},
+		},
+		{
+			description: "invalid scheme",
+			dsn:         "postgres://myproject/mydataset",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			cfg, err := ParseDSN(tc.dsn)
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, tc.expect.ProjectID, cfg.ProjectID)
+			assert.Equal(t, tc.expect.DatasetID, cfg.DatasetID)
+			assert.Equal(t, tc.expect.Location, cfg.Location)
+			assert.Equal(t, tc.expect.Priority, cfg.Priority)
+			assert.Equal(t, tc.expect.Reservation, cfg.Reservation)
+			assert.Equal(t, tc.expect.App, cfg.App)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,39 +1,37 @@
 module github.com/viant/bigquery
 
-go 1.22
+go 1.23.0
 
 toolchain go1.23.1
 
 require (
 	github.com/francoispqt/gojay v1.2.13
 	github.com/google/uuid v1.6.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/viant/afs v1.25.1-0.20231110184132-877ed98abca1
 	github.com/viant/assertly v0.9.1-0.20220620174148-bab013f93a60
 	github.com/viant/parsly v0.0.0-20220907184615-a27c125714a1
 	github.com/viant/scy v0.25.0
 	github.com/viant/xunsafe v0.9.3-0.20240530173106-69808f27713b
-	golang.org/x/oauth2 v0.19.0
-	google.golang.org/api v0.174.0
+	golang.org/x/oauth2 v0.28.0
+	google.golang.org/api v0.227.0
 )
 
 require (
-	cloud.google.com/go/auth v0.2.0 // indirect
-	cloud.google.com/go/auth/oauth2adapt v0.2.0 // indirect
-	cloud.google.com/go/compute/metadata v0.3.0 // indirect
+	cloud.google.com/go/auth v0.15.0 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
+	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
-	github.com/googleapis/gax-go/v2 v2.12.3 // indirect
+	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
+	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
@@ -44,19 +42,19 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/viant/toolbox v0.36.0 // indirect
 	github.com/viant/xreflect v0.6.2 // indirect
-	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.24.0 // indirect
-	go.opentelemetry.io/otel/metric v1.24.0 // indirect
-	go.opentelemetry.io/otel/trace v1.24.0 // indirect
-	golang.org/x/crypto v0.32.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
+	go.opentelemetry.io/otel v1.34.0 // indirect
+	go.opentelemetry.io/otel/metric v1.34.0 // indirect
+	go.opentelemetry.io/otel/trace v1.34.0 // indirect
+	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/net v0.34.0 // indirect
-	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be // indirect
-	google.golang.org/grpc v1.63.2 // indirect
-	google.golang.org/protobuf v1.33.0 // indirect
+	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
+	google.golang.org/grpc v1.71.0 // indirect
+	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/param/param_test.go
+++ b/internal/param/param_test.go
@@ -79,6 +79,7 @@ func TestParam_QueryParameterNew(t *testing.T) {
 
 		if !assert.EqualValues(t, expect, queryParam, testCase.description) {
 			actual, _ := json.Marshal(queryParam)
+			fmt.Println(string(actual))
 		}
 	}
 

--- a/internal/param/param_test.go
+++ b/internal/param/param_test.go
@@ -3,9 +3,10 @@ package param
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/bigquery/v2"
-	"testing"
 )
 
 func TestParam_QueryParameterNew(t *testing.T) {
@@ -78,7 +79,9 @@ func TestParam_QueryParameterNew(t *testing.T) {
 
 		if !assert.EqualValues(t, expect, queryParam, testCase.description) {
 			actual, _ := json.Marshal(queryParam)
-			fmt.Println(string(actual))
+			wexpect, _ := json.Marshal(expect)
+			fmt.Println(fmt.Sprintf("wexpect: %s", string(wexpect)))
+			fmt.Println(fmt.Sprintf("wectual: %s", string(actual)))
 		}
 	}
 

--- a/internal/param/param_test.go
+++ b/internal/param/param_test.go
@@ -79,9 +79,6 @@ func TestParam_QueryParameterNew(t *testing.T) {
 
 		if !assert.EqualValues(t, expect, queryParam, testCase.description) {
 			actual, _ := json.Marshal(queryParam)
-			wexpect, _ := json.Marshal(expect)
-			fmt.Println(fmt.Sprintf("wexpect: %s", string(wexpect)))
-			fmt.Println(fmt.Sprintf("wectual: %s", string(actual)))
 		}
 	}
 


### PR DESCRIPTION
More of proof of concept -- upgrade the google-go-api-client library to the required version increases the minimum required version of go to 1.23 instead of 1.22

Follow the pattern in #12 of supporting query-level params at the connection level -- would also be worth exploring use of the hint-type overrides once the library is on the newer version.