### PR TITLE
Fix isAuth to recognize WithCredentialsJSON from SetOptions

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -90,13 +90,13 @@ func isAuth(options []option.ClientOption) bool {
 	}
 	for _, opt := range options {
 		if _, ok := opt.(oauth2.TokenSource); ok {
-			return ok
-		}
-		if _, ok := opt.(oauth2.TokenSource); ok {
-			return ok
+			return true
 		}
 		optName := reflect.TypeOf(opt).String()
-		if strings.Contains(optName, "HTTP") || strings.Contains(optName, "Creds") {
+		// WithCredentialsJSON is option.withCredentialsJSON — match "Credentials", not just "Creds".
+		if strings.Contains(optName, "HTTP") ||
+			strings.Contains(optName, "Creds") ||
+			strings.Contains(optName, "Credentials") {
 			return true
 		}
 	}

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,0 +1,22 @@
+package bigquery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/option"
+)
+
+func TestIsAuth_withCredentialsJSON(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/viant-bigquery-isauth-test.json")
+
+	valid := []byte(`{"type":"service_account","project_id":"test"}`)
+	assert.True(t, isAuth([]option.ClientOption{option.WithCredentialsJSON(valid)}))
+}
+
+func TestIsAuth_emptyOptions(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/viant-bigquery-isauth-test.json")
+
+	assert.False(t, isAuth(nil))
+	assert.False(t, isAuth([]option.ClientOption{}))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,39 +1,37 @@
 module github.com/viant/bigquery
 
-go 1.22
+go 1.23.0
 
 toolchain go1.23.1
 
 require (
 	github.com/francoispqt/gojay v1.2.13
 	github.com/google/uuid v1.6.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/viant/afs v1.25.1-0.20231110184132-877ed98abca1
 	github.com/viant/assertly v0.9.1-0.20220620174148-bab013f93a60
 	github.com/viant/parsly v0.0.0-20220907184615-a27c125714a1
 	github.com/viant/scy v0.25.0
 	github.com/viant/xunsafe v0.11.0
-	golang.org/x/oauth2 v0.19.0
-	google.golang.org/api v0.174.0
+	golang.org/x/oauth2 v0.29.0
+	google.golang.org/api v0.229.0
 )
 
 require (
-	cloud.google.com/go/auth v0.2.0 // indirect
-	cloud.google.com/go/auth/oauth2adapt v0.2.0 // indirect
-	cloud.google.com/go/compute/metadata v0.3.0 // indirect
+	cloud.google.com/go/auth v0.16.0 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
-	github.com/googleapis/gax-go/v2 v2.12.3 // indirect
+	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
+	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
@@ -43,20 +41,18 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/viant/toolbox v0.36.0 // indirect
-	github.com/viant/xreflect v0.6.2 // indirect
-	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.24.0 // indirect
-	go.opentelemetry.io/otel/metric v1.24.0 // indirect
-	go.opentelemetry.io/otel/trace v1.24.0 // indirect
-	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/net v0.34.0 // indirect
-	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be // indirect
-	google.golang.org/grpc v1.63.2 // indirect
-	google.golang.org/protobuf v1.33.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
+	go.opentelemetry.io/otel v1.35.0 // indirect
+	go.opentelemetry.io/otel/metric v1.35.0 // indirect
+	go.opentelemetry.io/otel/trace v1.35.0 // indirect
+	golang.org/x/crypto v0.37.0 // indirect
+	golang.org/x/net v0.39.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
+	golang.org/x/text v0.24.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250414145226-207652e42e2e // indirect
+	google.golang.org/grpc v1.71.1 // indirect
+	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
`isAuth()` did not treat `option.WithCredentialsJSON` as an configured credential source. When callers set credentials via `SetOptions()` (rather than DSN params or ADC), the driver still fell back to scy interactive GCP auth and opened a browser.

This adds a type-name check for `"Credentials"` and tests for the `WithCredentialsJSON` path.